### PR TITLE
Include vias in the v8 Routes request

### DIFF
--- a/routingv8/request.go
+++ b/routingv8/request.go
@@ -49,6 +49,7 @@ type CalculateMatrixRequest struct {
 type RoutesRequest struct {
 	Origin        GeoWaypoint
 	Destination   GeoWaypoint
+	Via           []GeoWaypoint
 	TransportMode TransportMode
 	AvoidAreas    []AreaFeature
 	// Which attributes to return in the response.

--- a/routingv8/routes.go
+++ b/routingv8/routes.go
@@ -42,6 +42,9 @@ func (s *RoutingService) Routes(
 	values.Add("transportMode", tm)
 	values.Add("origin", fmt.Sprintf("%v,%v", req.Origin.Lat, req.Origin.Long))
 	values.Add("destination", fmt.Sprintf("%v,%v", req.Destination.Lat, req.Destination.Long))
+	for _, via := range req.Via {
+		values.Add("via", fmt.Sprintf("%v,%v", via.Lat, via.Long))
+	}
 	if len(req.Spans) > 0 {
 		if !returnContains(req.Return, PolylineReturnAttribute) {
 			return nil, errors.New("spans parameter also requires that the polyline option is set in the return parameter")

--- a/routingv8/routes_test.go
+++ b/routingv8/routes_test.go
@@ -199,6 +199,27 @@ func TestRoutingervice_Routes_QueryParams(t *testing.T) {
 			},
 			errStr: "spans parameter also requires that the polyline option is set in the return parameter",
 		},
+		{
+			name: "with vias",
+			request: &routingv8.RoutesRequest{
+				Origin:      origin,
+				Destination: destination,
+				Via: []routingv8.GeoWaypoint{
+					{
+						Lat:  57.695538,
+						Long: 11.992594,
+					},
+					{
+						Lat:  59.323410,
+						Long: 18.096137,
+					},
+				},
+				TransportMode: routingv8.TransportModeCar,
+			},
+			expected: "destination=59.337492%2C18.063672&origin=57.707752%2C11.949767" +
+				"&return=summary&transportMode=car" +
+				"&via=57.695538%2C11.992594&via=59.32341%2C18.096137",
+		},
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Include a Via parameter in the RoutesRequest.
This can be used to include multiple Waypoints to be used between the Origin and Destination when calling the \routes API.